### PR TITLE
Fixing Transition method name from about to abort.

### DIFF
--- a/src/components/about/aboutPage.js
+++ b/src/components/about/aboutPage.js
@@ -6,7 +6,7 @@ var About = React.createClass({
 	statics: {
 		willTransitionTo: function(transition, params, query, callback) {
 			if (!confirm('Are you sure you want to read a page that\'s this boring?')) {
-				transition.about();
+				transition.abort();
 			} else {
 				callback();
 			}
@@ -14,7 +14,7 @@ var About = React.createClass({
 		
 		willTransitionFrom: function(transition, component) {
 			if (!confirm('Are you sure you want to leave a page that\'s this exciting?')) {
-				transition.about();
+				transition.abort();
 			}
 		}
 	},


### PR DESCRIPTION
There seems to be a typo in the method name.
Strangely, this doesn't change the behavior of aboutPage.js transitions.